### PR TITLE
Print "none" instead of "uninitialized value" warnings.

### DIFF
--- a/examples/vehicle.pl
+++ b/examples/vehicle.pl
@@ -12,9 +12,9 @@ printf(
 );
 
 printf(
-    "My car is in gear %s and is currently going %d MPH and my odometer is %d\n",
-    $car->gear,
-    $car->speed,
+    "My car is in gear %s and is currently going %s MPH and my odometer is %d\n",
+    $car->gear // "none",
+    $car->speed // "none",
     $car->odometer
 );
 
@@ -34,11 +34,11 @@ printf(
 );
 
 printf(
-    "My battery is at %d%%, and is %s charging at %.2f volts pulling %.2f Amps\n",
+    "My battery is at %d%%, and is %s charging at %.2f volts pulling %s Amps\n",
     $car->battery_level,
     $car->charging_state ? 'currently' : 'not',
     $car->charger_voltage,
-    $car->charge_actual_current
+    $car->charge_actual_current // "none"
 );
 
 if ($car->battery_level >= $car->charge_limit_soc) {


### PR DESCRIPTION
Before (parked M3P):
```
My Tesla account has my car registered with the name 'Tesla'.
Use of uninitialized value in printf at vehicle.pl line 14.
Use of uninitialized value in printf at vehicle.pl line 14.
My car is in gear  and is currently going 0 MPH and my odometer is 7589
My latitude is 50.764024, longitide is 15.269074, my heading is 50 degrees and its using 0.00 kWh/mile
My dashcam is Unavailable, sentry mode is disabled and I am not currently near my vehicle
Use of uninitialized value in printf at vehicle.pl line 36.
My battery is at 79%, and is currently charging at 2.00 volts pulling 0.00 Amps
...
```
After:
```
My Tesla account has my car registered with the name 'Tesla'.
My car is in gear none and is currently going none MPH and my odometer is 7589
My latitude is 50.764024, longitide is 15.269074, my heading is 50 degrees and its using 0.00 kWh/mile
My dashcam is Unavailable, sentry mode is disabled and I am not currently near my vehicle
My battery is at 79%, and is currently charging at 2.00 volts pulling none Amps
...
```
