### PR TITLE
Fix 5 retries on each API access

### DIFF
--- a/lib/Tesla/Vehicle.pm
+++ b/lib/Tesla/Vehicle.pm
@@ -125,7 +125,7 @@ sub data {
         return {};
     }
 
-    if (! defined $data->{drive_state}{shift_state}) {
+    if (! defined $data->{drive_state}{timestamp}) {
 
         for (1 .. API_RETRIES) {
             print "API retry attempt $_\n" if DEBUG_API_RETRY;
@@ -134,7 +134,7 @@ sub data {
 
             $data = $self->api(endpoint => 'VEHICLE_DATA', id => $self->id);
 
-            if (defined $data->{drive_state}{shift_state}) {
+            if (defined $data->{drive_state}{timestamp}) {
                 last;
             }
         }


### PR DESCRIPTION
Reproducer:
```
TESLA_DEBUG_ONLINE=1 TESLA_DEBUG_API_RETRY=1 time perl -MTesla::Vehicle -e 'print Tesla::Vehicle->new(auto_wake=>1)->battery_level."\n"'
```
Before the patch:
```
Vehicle is ONLINE
API retry attempt 1
API retry attempt 2
API retry attempt 3
API retry attempt 4
API retry attempt 5
49
0.35user 0.02system 0:16.17elapsed 2%CPU (0avgtext+0avgdata 38912maxresident)k
```

After the patch:
```
Vehicle is ONLINE
49
0.20user 0.01system 0:05.12elapsed 4%CPU (0avgtext+0avgdata 38572maxresident)k
```

Data of my vehicle:
```
          'drive_state' => {
                             'active_route_destination' => 'Smart Summon',
                             'active_route_latitude' => 'XXX',
                             'active_route_longitude' => 'XXX',
                             'active_route_traffic_minutes_delay' => '0',
                             'gps_as_of' => 1694862998,
                             'heading' => 48,
                             'latitude' => 'XXX',
                             'longitude' => 'XXX',
                             'native_latitude' => 'XXX',
                             'native_location_supported' => 1,
                             'native_longitude' => 'XXX',
                             'native_type' => 'wgs',
                             'power' => 0,
---------------------------> 'shift_state' => undef,
                             'speed' => undef,
                             'timestamp' => '1696481629069'
                           },
```
